### PR TITLE
preset-latest is deprecated use preset-env instead

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,5 @@
 {
   "presets": [
-    "latest"
+    "env"
   ]
 }


### PR DESCRIPTION
`{ "presets": ["latest"] } === { "presets": ["env"] }`